### PR TITLE
Language cleanups and updates

### DIFF
--- a/index.html
+++ b/index.html
@@ -126,12 +126,12 @@
 
             <section id="workstation" class="work section">
                 <div class="container">
-                    <h2 class="title">Why you need to test for lead</h2>
+                    <h2 class="title">Why test for lead</h2>
                     <p>
-                        Most people heard about the lead contamination crisis in Flint, Michigan. But many people don't realize that because of old houses, aging infrastructure, and lax regulatations, water issues are a problem in many communities around the country.
+                        Most people heard about the water crisis in Flint, Michigan. But many people don't realize that because of old houses, aging infrastructure, and lax regulatations, water issues are a problem in many communities around the country.
                     </p>
                     <p>
-                        Reuters recently found <a href="http://www.reuters.com/investigates/special-report/usa-lead-testing/">lead poisoning in over 3,000 communities</a> across the United States with rates double - or worse - than were found in Flint, Michigan.
+                        The CDC, pediatricians and health professionals, and even the EPA all say: <strong>There is NO safe amount of lead.</strong> Even a little bit of lead can build up over time and be harmful, particularly to growing kids and people with health concerns. We aren't in the business of scaring you into buying a test. But lead in drinking water is, unfortunately, a real issue around the country. Reuters recently found <a href="http://www.reuters.com/investigates/special-report/usa-lead-testing/">lead poisoning in over 3,000 communities</a> across the United States with rates double - or worse - than were found in Flint, Michigan.
                     </p>
                     <br>
                     <br>
@@ -140,14 +140,9 @@
                             <div class="vira-card">
                                 <div class="vira-card-content">
                                     <h3>Living in a house built before 1986</h3>
-
                                     <p>
-                                        Lead pipes were extremely common in houses built before 1986? Unfortunately, most houses in the United States were built before 1986.
+                                        Lead pipes were legal and commonly used before 1986, both in main city pipes and in individual home constructions. While some houses have had their pipes replaced, many have not. Further, many cities haven't replaced their lead pipes due to costs.
                                     </p>
-                                    <p>
-                                        While some houses have had their plumbing replaced, many have not. The government does not monitor what pipes inside houses are made from. 
-                                    <p>
-                                        Anyone living in an older house should check what their pipes are made from or have their water tested immediately.  
                                 </div>
                             </div>
                         </div>
@@ -156,12 +151,9 @@
                                 <div class="vira-card-content">
                                     <h3>You can't see or taste lead</h3>
                                     <p>
-                                        Unlike other water contaminants, lead in your water is invisible. And health experts all agree: lead is terrible for your brain and body. 
+                                        Unlike other water contaminants, lead in your water is invisible. 
                                     <p>
-                                        It hinders brain function, stunts growth in children, has long-term health implications, and can even be fatal. 
-                                    </p>
-                                    <p>
-                                        There is an EPA-set acceptable threshhold of lead in water, but there is no "safe" amount of lead. It's especially dangerous for infants, children, and the infirm.
+                                        And health experts all agree: lead is terrible for your brain and body. It hinders brain function, stunts growth in children, has long-term health implications, and can even be fatal. 
                                     </p>
                                 </div>
                             </div>
@@ -171,9 +163,7 @@
                                 <div class="vira-card-content">
                                     <h3>Routine testing doesn't test your house</h3>
                                     <p>
-                                        Most water testing is done by the local water utility at their treatment plants. 
-                                    <p>
-                                        But after that, water travels inside water mains buried under the streets, into the water pipes under your house, through your sink's pipes, and out your faucet. 
+                                        Most water testing is done by the local water utility at their treatment plants. But after that, water travels inside water mains buried under the streets, through an s-shaped connector, into the water pipes under your house, through your sink's pipes, and out your faucet. 
                                     </p>
                                     <p>
                                         Lead could get in your water from any of these places before you drink it. 
@@ -202,10 +192,6 @@
                     <div class="row">
                         <div class="col-sm-8 col-sm-offset-2">
                             <h2 class="title">We make water testing easy</h2>
-                            <br>
-                    <p>
-                        We aren't in the business of scaring you into buying a test. But lead in drinking water is, unfortunately, a real issue around the country. We want to give you the peace of mind that the water you and your family are consuming is safe and lead-free.
-                    </p>
                             <div class="comparison">
                                 <img src="assets/images/comparison.png" width="1000">
                             </div>
@@ -218,7 +204,7 @@
                 <div class="container">
                     <h2 class="title">Here's how it works</h2>
                         <p>
-                            We don't use cheap, unreliable testing strips you can find on Amazon or at your department store. Instead, we send your sample to our <a href="#expertise">professional, government-certified partner laboratories</a>. They test your water using a highly accurate, state of the art method called <a href="https://en.wikipedia.org/wiki/Inductively_coupled_plasma_mass_spectrometry">inductively coupled plasma mass spectrometry</a>.
+                            We want to give you the peace of mind that the water you and your family are consuming is safe and lead-free. So we don't use cheap, unreliable testing strips found on Amazon or at your department store. Instead, we send your sample to our professional, government-certified partner laboratories. They test your water using a highly accurate, state-of-the-art method called <a href="https://en.wikipedia.org/wiki/Inductively_coupled_plasma_mass_spectrometry">inductively coupled plasma mass spectrometry</a>.
                         </p>
                         <br>
                     <div class="row">
@@ -281,7 +267,7 @@
                     <div class="row">
                         <div class="col-sm-12">
                             <p>
-                                For only $40, have your water professionally tested today. Now with free shipping.</p>
+                                For $40 (shipping included), have your water professionally tested today.</p>
                             </p>
                             <!--
                                 <form action="//hestiaworks.us16.list-manage.com/subscribe/post?u=1cc36e73c1fe8e880c43734a8&amp;id=78db9e556e" method="post" id="mc-embedded-subscribe-form" name="mc-embedded-subscribe-form" class="form-inline" target="_blank" novalidate>
@@ -409,13 +395,18 @@
                             We found a number of testing kits online and in stores, but those weren't very trustworthy. Then we tried to contact our local water testing labs, but ordering a single test was complicated. Government labs were too slow, hard to navigate, and face-less. Commercial labs were too expensive and only provided the data - no recommendations for what to do next. Both told us they spend most of their time with industry and companies.
                         </p>
                         <p>
-                            So we made a company.
+                            <strong>So we made a company.</strong>
                         </p>
                         <p>
-                            We've found the top professional, government-certified labs so you don't have to do the searching. We've figured out how to work with them so you don't have to. We can take advantage of volume pricing to get you cheaper tests. We can take care of all the complicated business stuff these labs want, so all you have to do is click a button to order a test.
+                             So we started a company.
+                        <p>
+                            We think this process should be easy. So * We found the top professional, government-certified labs so that you don't have to do the searching. * We figured out how to work with them so you don't have to. * You get take advantage of volume pricing to get you cheaper tests. * We take care of the business stuff these labs need * All you have to do is click a button to order a test. 
                         </p>
                         <p>
-                            We simplify things for you, because your world is complicated enough. We'll help you understand what's coming out of your tap and how it might effect your family's health.
+                             Water is important! After years of under investment in public infrastructure, and with the changes of climate change now affecting us, we fear that the days of taking the safety of our drinking water for granted may be behind us. We hope and advocate for policies to modernize our water system. In fact we hope those happen and they take us out of business.
+                        </p>
+                        <p>
+                             But in the mean time, we think you may want to consider your water and test it yourself, if only just to make sure. And we’ve built a product and service that makes that process simple, fast, and trustworthy. 
                         </p>
                     </div>
                     <div class="row">
@@ -463,10 +454,10 @@
                     <div class="row">
                         <div class="col-sm-12">
                             <p>
-                                For only $40, with free shipping, are you ready to make sure your drinking water is lead-free? 
+                                Are you ready to esure your drinking water is lead-free? A single test is $40 (shipping included).
                             </p>
                             <!-- embedded, formcrafts --> 
-                            <script type='text/javascript'>var _fo=_fo||[];_fo.push({'d':'center','c':'faa108','i':29776});if(typeof fce=='undefined'){var s=document.createElement('script');s.type='text/javascript';s.async=true;s.src='https://'+'formcrafts.com/js/fc.js';var fi=document.getElementsByTagName('script')[0];fi.parentNode.insertBefore(s,fi);fce=1;}</script><div id='faa108'><a href='http://formcrafts.com/a/29776'>Test Your Water For Lead</a></div><a class='fcpbl center' href='https://formcrafts.com/?pw=pwl'>created with <span>FormCrafts</span></a>
+                            <script type='text/javascript'>var _fo=_fo||[];_fo.push({'d':'center','c':'faa108','i':29776});if(typeof fce=='undefined'){var s=document.createElement('script');s.type='text/javascript';s.async=true;s.src='https://'+'formcrafts.com/js/fc.js';var fi=document.getElementsByTagName('script')[0];fi.parentNode.insertBefore(s,fi);fce=1;}</script><div id='faa108'><a href='http://formcrafts.com/a/29776'>Test Your Water For Lead</a></div>
 
 <!--                            <p>
                                 Give us your email address, and test your water today.</p>
@@ -485,13 +476,10 @@
                 <div class="container">
                     <div class="row">
                         <div class="col-sm-12">
-                            <p>
-                                Want to do more reading? Here are a few articles and websites related to this issue:<br>
-                            </p>
-                            <p>
+                                Want to do more reading? Here are a few articles and websites related to this issue:
+                            <br><br>
                                 <a href="https://www.usatoday.com/story/news/2016/03/16/testing-assessing-safety-of-drinking-water-lead-contamination/80504058/#">USA Today: Got Lead in Your Water? It’s Not Easy to Find Out</a> | <a href="http://www.webmd.com/special-reports/lead-dangers/20170612/high-lead-test-no-one-told-her">WebMD: Her Home Showed High Lead. She Wasn’t Told.</a> | <a href="http://www.reuters.com/investigates/special-report/usa-lead-testing/">Reuters: The Thousands of Locales where Lead Poisoning is Worse than Flint</a> | <a href="https://www.epa.gov/ground-water-and-drinking-water/basic-information-about-lead-drinking-water">US EPA: Basic Information about Lead in Drinking Water</a> | <a href="https://www.cdc.gov/nceh/lead/tips/water.htm">CDC: Lead in Drinking Water</a> | <a href="http://www.mayoclinic.org/diseases-conditions/lead-poisoning/home/ovc-20275050">The Mayo Clinic: Overview on Lead Poisoning</a>
-
-                            </p>
+                            
                         </div>
                     </div>
                 </div>


### PR DESCRIPTION
Language cleanup through a few places
Changed "Why you need to test for lead" --> "Why test for lead"
Shortened text in the 3 'Why Test' blocks
Added line re CDC and EPA recommendations to upper section
Elsewhere: Swapped the comparison chart image
Updated Our Story text, from readgeoffrey.github.io/Atomic82 language
Removed formatting in footer text